### PR TITLE
Add getXYZ to get 3 axis data at the same time

### DIFF
--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -170,7 +170,7 @@ int16_t Adafruit_ADXL343::getZ(void) { return read16(ADXL343_REG_DATAZ0); }
     @param x reference to return x acceleration data
     @param y reference to return y acceleration data
     @param z reference to return z acceleration data
-    @return either success or fail to get data
+    @return True if the operation was successful, otherwise false.
 */
 /**************************************************************************/
 bool Adafruit_ADXL343::getXYZ(int16_t &x, int16_t &y, int16_t &z) {

--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -176,7 +176,7 @@ int16_t Adafruit_ADXL343::getZ(void) { return read16(ADXL343_REG_DATAZ0); }
 bool Adafruit_ADXL343::getXYZ(int16_t &x, int16_t &y, int16_t &z) {
   int16_t buffer[] = {0, 0, 0};
   Adafruit_BusIO_Register reg_obj = Adafruit_BusIO_Register(
-      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, ADXL343_REG_DATAX0, 6);
+      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, ADXL3XX_REG_DATAX0, 6);
   if (!reg_obj.read((uint8_t *)&buffer, 6))
     return false;
   x = buffer[0];

--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -166,6 +166,27 @@ int16_t Adafruit_ADXL343::getZ(void) { return read16(ADXL343_REG_DATAZ0); }
 
 /**************************************************************************/
 /*!
+    @brief  Reads 3x16-bits from the x, y, and z data register
+    @param x reference to return x acceleration data
+    @param y reference to return y acceleration data
+    @param z reference to return z acceleration data
+    @return either success or fail to get data
+*/
+/**************************************************************************/
+bool Adafruit_ADXL343::getXYZ(int16_t &x, int16_t &y, int16_t &z) {
+  int16_t buffer[] = {0, 0, 0};
+  Adafruit_BusIO_Register reg_obj = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, ADXL343_REG_DATAX0, 6);
+  if(!reg_obj.read((uint8_t*)&buffer, 6))
+    return false;
+  x = buffer[0];
+  y = buffer[1];
+  z = buffer[2];
+  return true;
+}
+
+/**************************************************************************/
+/*!
  *   @brief  Instantiates a new ADXL343 class
  *
  *   @param sensorID  An optional ID # so you can track this sensor, it will
@@ -360,6 +381,7 @@ dataRate_t Adafruit_ADXL343::getDataRate(void) {
 */
 /**************************************************************************/
 bool Adafruit_ADXL343::getEvent(sensors_event_t *event) {
+  int16_t x, y, z;
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
 
@@ -367,12 +389,11 @@ bool Adafruit_ADXL343::getEvent(sensors_event_t *event) {
   event->sensor_id = _sensorID;
   event->type = SENSOR_TYPE_ACCELEROMETER;
   event->timestamp = millis();
-  event->acceleration.x =
-      getX() * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.y =
-      getY() * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.z =
-      getZ() * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  if(!getXYZ(x, y, z))
+    return false;
+  event->acceleration.x = x * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.y = y * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.z = z * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
 
   return true;
 }

--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -177,7 +177,7 @@ bool Adafruit_ADXL343::getXYZ(int16_t &x, int16_t &y, int16_t &z) {
   int16_t buffer[] = {0, 0, 0};
   Adafruit_BusIO_Register reg_obj = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, AD8_HIGH_TOREAD_AD7_HIGH_TOINC, ADXL343_REG_DATAX0, 6);
-  if(!reg_obj.read((uint8_t*)&buffer, 6))
+  if (!reg_obj.read((uint8_t *)&buffer, 6))
     return false;
   x = buffer[0];
   y = buffer[1];
@@ -389,11 +389,14 @@ bool Adafruit_ADXL343::getEvent(sensors_event_t *event) {
   event->sensor_id = _sensorID;
   event->type = SENSOR_TYPE_ACCELEROMETER;
   event->timestamp = millis();
-  if(!getXYZ(x, y, z))
+  if (!getXYZ(x, y, z))
     return false;
-  event->acceleration.x = x * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.y = y * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.z = z * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.x =
+      x * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.y =
+      y * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.z =
+      z * ADXL343_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
 
   return true;
 }

--- a/Adafruit_ADXL343.h
+++ b/Adafruit_ADXL343.h
@@ -153,6 +153,7 @@ public:
   int16_t getX(void);
   int16_t getY(void);
   int16_t getZ(void);
+  bool getXYZ(int16_t &x, int16_t &y, int16_t &z);
 
 private:
   Adafruit_SPIDevice *spi_dev = NULL;


### PR DESCRIPTION
Scope of change:
1. add getXYZ method to read 3-axis data at the same time to improve fetch performance.
2. modify getEvent to use getXYZ instead of using getX, getY, and getZ individually.

Already tested on sensortest example and worked.
