### PR TITLE
added support for alternative I2C address allowing two sensors 

### DIFF
--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -186,6 +186,21 @@ Adafruit_ADXL343::Adafruit_ADXL343(int32_t sensorID) {
  *   @param wireBus   TwoWire instance to use for I2C communication.
  */
 /**************************************************************************/
+Adafruit_ADXL343::Adafruit_ADXL343(int32_t sensorID, bool altAddress) {
+  _sensorID = sensorID;
+  _wire = &Wire;
+  _altAddress = altAddress;
+}
+
+/**************************************************************************/
+/*!
+ *   @brief  Instantiates a new ADXL343 class
+ *
+ *   @param sensorID  An optional ID # so you can track this sensor, it will
+ *                    tag sensorEvents you create.
+ *   @param wireBus   TwoWire instance to use for I2C communication.
+ */
+/**************************************************************************/
 Adafruit_ADXL343::Adafruit_ADXL343(int32_t sensorID, TwoWire *wireBus) {
   _sensorID = sensorID;
   _wire = wireBus;
@@ -222,6 +237,10 @@ Adafruit_ADXL343::Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi,
 /**************************************************************************/
 bool Adafruit_ADXL343::begin(uint8_t i2caddr) {
 
+  if (_altAddress) {
+    i2caddr = ADXL343_ALT_ADDRESS; //overwrite default I2C address
+  }
+  
   if (_wire) {
     if (i2c_dev) {
       delete i2c_dev; // remove old interface

--- a/Adafruit_ADXL343.h
+++ b/Adafruit_ADXL343.h
@@ -32,7 +32,8 @@
 /*=========================================================================
     I2C ADDRESS/BITS
     -----------------------------------------------------------------------*/
-#define ADXL343_ADDRESS (0x53) /**< Assumes ALT address pin low */
+#define ADXL343_ADDRESS (0x53) /**< Assumes ALT address pin low, is the default */
+#define ADXL343_ALT_ADDRESS (0x1D) /**< Assumes ALT address pin high */
 /*=========================================================================*/
 
 /*=========================================================================
@@ -156,6 +157,7 @@ typedef enum {
 class Adafruit_ADXL343 : public Adafruit_Sensor {
 public:
   Adafruit_ADXL343(int32_t sensorID);
+  Adafruit_ADXL343(int32_t sensorID, bool altAddress);
   Adafruit_ADXL343(int32_t sensorID, TwoWire *wireBus);
   Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi, uint8_t cs,
                    int32_t sensorID = -1);
@@ -189,12 +191,14 @@ protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< BusIO I2C device
 
   TwoWire *_wire;         ///< I2C hardware interface
+  bool _altAddress;       ///< User-set flag to use alt I2C address (see datasheet)
   int32_t _sensorID;      ///< User-set sensor identifier
   adxl34x_range_t _range; ///< cache of range
   uint8_t _clk,           ///< SPI software clock
       _do,                ///< SPI software data out
       _di,                ///< SPI software data in
       _cs;                ///< SPI software chip select
+  
 };
 
 #endif

--- a/examples/sensortest/sensortest.ino
+++ b/examples/sensortest/sensortest.ino
@@ -16,7 +16,7 @@ Adafruit_ADXL343 accel = Adafruit_ADXL343(12345);
 /* Uncomment following line for default Wire bus      */
 /* and alternative I2C address 0X1D. Connect pin SDO  */
 /* to Vcc for this. */
-Adafruit_ADXL343 accel = Adafruit_ADXL343(12345, true);
+//Adafruit_ADXL343 accel = Adafruit_ADXL343(12345, true);
 
 /* NeoTrellis M4, etc.                    */
 /* Uncomment following line for Wire1 bus */

--- a/examples/sensortest/sensortest.ino
+++ b/examples/sensortest/sensortest.ino
@@ -9,7 +9,14 @@
 
 /* Assign a unique ID to this sensor at the same time */
 /* Uncomment following line for default Wire bus      */
+/* and default I2C address 0X53                       */
 Adafruit_ADXL343 accel = Adafruit_ADXL343(12345);
+
+/* Assign a unique ID to this sensor at the same time */
+/* Uncomment following line for default Wire bus      */
+/* and alternative I2C address 0X1D. Connect pin SDO  */
+/* to Vcc for this. */
+Adafruit_ADXL343 accel = Adafruit_ADXL343(12345, true);
 
 /* NeoTrellis M4, etc.                    */
 /* Uncomment following line for Wire1 bus */


### PR DESCRIPTION
Added support using a boolean flag when constructing the ADXL343 class to signal the use of the alternative I2C address.

On breakout boards, the I2C address is set to the alternative (of 0x1D) by connecting SDO to Vcc. Also added a link to the sensortest example to illustrate the use.

Changes are in:
### Adafruit_ADXL343.h
- added: ```#define ADXL343_ALT_ADDRESS (0x1D) ```
- added ```Adafruit_ADXL343(int32_t sensorID, bool altAddress);``` as a constructor option for the class
- added ```bool _altAddress;``` as a protected field for the class 
### Adafruit_ADXL343.cpp
- added ```Adafruit_ADXL343::Adafruit_ADXL343(int32_t sensorID, bool altAddress) {
  _sensorID = sensorID;
  _wire = &Wire;
  _altAddress = altAddress;
}``` constructor function. 
- added ```  if (_altAddress) {
    i2caddr = ADXL343_ALT_ADDRESS; //overwrite default I2C address
  }``` to the begin() function to change I2C address when needed.
### sensortest.ino
added:
```
/* Assign a unique ID to this sensor at the same time */
/* Uncomment following line for default Wire bus      */
/* and alternative I2C address 0X1D. Connect pin SDO  */
/* to Vcc for this. */
//Adafruit_ADXL343 accel = Adafruit_ADXL343(12345, true);
```
as an example of how to use the added feature.

Thanks for reviewing, hope this contributes to the broader use of these boards!

Rolf Hut