### PR TITLE
Add HW SPI support

### DIFF
--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -214,14 +214,14 @@ Adafruit_ADXL343::Adafruit_ADXL343(int32_t sensorID, TwoWire *wireBus) {
 
 /**************************************************************************/
 /*!
-    @brief  Instantiates a new ADXL343 class in SPI mode
+    @brief  Instantiates a new ADXL343 class in software SPI mode
 
     @param clock The SCK pin
     @param miso The MISO pin
     @param mosi The MOSI pin
     @param cs The CS/SSEL pin
     @param sensorID An optional ID # so you can track this sensor, it will tag
-           sensoorEvents you create.
+           sensorEvents you create.
 */
 /**************************************************************************/
 Adafruit_ADXL343::Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi,
@@ -236,6 +236,23 @@ Adafruit_ADXL343::Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi,
 
 /**************************************************************************/
 /*!
+    @brief  Instantiates a new ADXL343 class in hardware SPI mode
+
+    @param cs The CS/SSEL pin
+    @param sensorID An optional ID # so you can track this sensor, it will tag
+           sensorEvents you create.
+*/
+/**************************************************************************/
+Adafruit_ADXL343::Adafruit_ADXL343(uint8_t cs, SPIClass *theSPI,
+                                   int32_t sensorID) {
+  _sensorID = sensorID;
+  _cs = cs;
+  _spi = theSPI;
+  _wire = NULL;
+}
+
+/**************************************************************************/
+/*!
     @brief  Setups the HW (reads coefficients values, etc.)
     @param  i2caddr The 7-bit I2C address to find the ADXL on
     @return True if the sensor was successfully initialised.
@@ -244,6 +261,7 @@ Adafruit_ADXL343::Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi,
 bool Adafruit_ADXL343::begin(uint8_t i2caddr) {
 
   if (_wire) {
+    //-- I2C --------------
     if (i2c_dev) {
       delete i2c_dev; // remove old interface
     }
@@ -254,15 +272,27 @@ bool Adafruit_ADXL343::begin(uint8_t i2caddr) {
     }
 
   } else {
+    //-- SPI --------------
     i2c_dev = NULL;
 
     if (spi_dev) {
       delete spi_dev; // remove old interface
     }
-    spi_dev = new Adafruit_SPIDevice(_cs, _clk, _di, _do,
-                                     1000000,               // frequency
-                                     SPI_BITORDER_MSBFIRST, // bit order
-                                     SPI_MODE3);            // data mode
+    if (_spi) {
+      // hardware spi
+      spi_dev = new Adafruit_SPIDevice(_cs,
+                                       1000000,               // frequency
+                                       SPI_BITORDER_MSBFIRST, // bit order
+                                       SPI_MODE3,             // data mode
+                                       _spi);                 // hardware SPI
+    } else {
+      // software spi
+      spi_dev = new Adafruit_SPIDevice(_cs, _clk, _di, _do,
+                                       1000000,               // frequency
+                                       SPI_BITORDER_MSBFIRST, // bit order
+                                       SPI_MODE3);            // data mode
+    }
+
     if (!spi_dev->begin()) {
       return false;
     }

--- a/Adafruit_ADXL343.cpp
+++ b/Adafruit_ADXL343.cpp
@@ -239,6 +239,7 @@ Adafruit_ADXL343::Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi,
     @brief  Instantiates a new ADXL343 class in hardware SPI mode
 
     @param cs The CS/SSEL pin
+    @param theSPI SPIClass instance to use for SPI communication.
     @param sensorID An optional ID # so you can track this sensor, it will tag
            sensorEvents you create.
 */

--- a/Adafruit_ADXL343.h
+++ b/Adafruit_ADXL343.h
@@ -26,6 +26,7 @@
 
 #include <Adafruit_BusIO_Register.h>
 #include <Adafruit_I2CDevice.h>
+#include <Adafruit_SPIDevice.h>
 #include <Adafruit_Sensor.h>
 #include <Wire.h>
 
@@ -159,6 +160,7 @@ public:
   Adafruit_ADXL343(int32_t sensorID, TwoWire *wireBus);
   Adafruit_ADXL343(uint8_t clock, uint8_t miso, uint8_t mosi, uint8_t cs,
                    int32_t sensorID = -1);
+  Adafruit_ADXL343(uint8_t cs, SPIClass *theSPI, int32_t sensorID = -1);
 
   bool begin(uint8_t i2caddr = ADXL343_ADDRESS);
   void setRange(adxl34x_range_t range);
@@ -189,7 +191,8 @@ protected:
   Adafruit_SPIDevice *spi_dev = NULL; ///< BusIO SPI device
   Adafruit_I2CDevice *i2c_dev = NULL; ///< BusIO I2C device
 
-  TwoWire *_wire;         ///< I2C hardware interface
+  TwoWire *_wire = NULL;  ///< I2C hardware interface
+  SPIClass *_spi = NULL;  ///< SPI hardware interface
   int32_t _sensorID;      ///< User-set sensor identifier
   adxl34x_range_t _range; ///< cache of range
   uint8_t _clk,           ///< SPI software clock

--- a/examples/sensortest/sensortest.ino
+++ b/examples/sensortest/sensortest.ino
@@ -15,8 +15,11 @@ Adafruit_ADXL343 accel = Adafruit_ADXL343(12345);
 /* Uncomment following line for Wire1 bus */
 //Adafruit_ADXL343 accel = Adafruit_ADXL343(12345, &Wire1);
 
-/* Uncomment for SPI */
+/* Uncomment for software SPI */
 //Adafruit_ADXL343 accel = Adafruit_ADXL343(ADXL343_SCK, ADXL343_MISO, ADXL343_MOSI, ADXL343_CS, 12345);
+
+/* Uncomment for hardware SPI */
+//Adafruit_ADXL343 accel = Adafruit_ADXL343(ADXL343_CS, &SPI, 12345);
 
 void displayDataRate(void)
 {


### PR DESCRIPTION
For #11. Adds HW SPI support.

This is a bit clunky, unfortunately. The existing ctor
```cpp
  Adafruit_ADXL343(int32_t sensorID);
```
prevents using:
```cpp
  Adafruit_ADXL343(uint8_t cs, SPIClass *theSPI = &SPI, int32_t sensorID = -1);
```
to allow specifying only CS as a way to setup HW SPI, since it will be ambiguous.

So made it so the SPI bus must be explicitly specified along with CS. See new addition to example:
```cpp
//Adafruit_ADXL343 accel = Adafruit_ADXL343(ADXL343_CS, &SPI, 12345);
```

Works though. Tested on Itsy M4:
![Screenshot from 2022-06-07 13-49-12](https://user-images.githubusercontent.com/8755041/172480865-b13fcd28-9a6e-488e-a159-5e4e29ff5921.png)

